### PR TITLE
download the latest Firefox coverage build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # coverage-crawler
+
+[![Build Status](https://travis-ci.org/marco-c/coverage-crawler.svg?branch=master)](https://travis-ci.org/marco-c/coverage-crawler)
+
 A crawler to find websites that exercise code in Firefox that is not covered by unit tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # coverage-crawler
-
 [![Build Status](https://travis-ci.org/marco-c/coverage-crawler.svg?branch=master)](https://travis-ci.org/marco-c/coverage-crawler)
 
 A crawler to find websites that exercise code in Firefox that is not covered by unit tests

--- a/latest_cov_build.py
+++ b/latest_cov_build.py
@@ -6,16 +6,18 @@ try:
 except ImportError:
     from urllib import urlretrieve
 
-
+# Retrieving task from index
 index = taskcluster.Index()
 taskId = index.findTask('gecko.v2.mozilla-central.' +
                         'latest.firefox.linux64-ccov-opt')['taskId']
+# Retrieving artifact from Queue
 queue = taskcluster.Queue()
 url = queue.buildUrl('getLatestArtifact', taskId,
                      'public/build/target.tar.bz2')
 name = os.path.join('ccov-artifacts', taskId +
                     'artifacts.public.build.target.tar.bz2')
 urlretrieve(url, name)
+# Extracting artifact
 with tarfile.open(name, 'r:bz2') as tar:
     tar.extractall()
 os.remove(name)

--- a/latest_cov_build.py
+++ b/latest_cov_build.py
@@ -1,0 +1,25 @@
+import tarfile
+import sys
+import json
+import os
+from urllib import urlretrieve, urlencode
+from urllib2 import urlopen
+
+
+def get_json(url, params=None):
+    if params is not None:
+        url += '?' + urlencode(params)
+
+    r = urlopen(url).read().decode('utf-8')
+
+    return json.loads(r)
+
+last_task = get_json('https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.firefox.linux64-ccov-opt')
+taskId = last_task['taskId']
+name = os.path.join('ccov-artifacts', taskId + 'artifacts.public.build.target.tar.bz2')
+urlretrieve('https://queue.taskcluster.net/v1/task/' + taskId + '/artifacts/public/build/target.tar.bz2', name)
+tar = tarfile.open(name, 'r:bz2')
+tar.extractall()
+tar.close()
+# target.tar.bz2 deleted
+os.remove(name)

--- a/latest_cov_build.py
+++ b/latest_cov_build.py
@@ -1,25 +1,20 @@
 import os
 import tarfile
 
-import taskcluster
-
 try:
     from urllib.request import urlretrieve
 except ImportError:
     from urllib import urlretrieve
 
 
-# Retrieving task from index
-index = taskcluster.Index()
-taskId = index.findTask('gecko.v2.mozilla-central.' +
-                        'latest.firefox.linux64-ccov-opt')['taskId']
-# taskId uniquelly identifies artifact
-name = os.path.join('ccov-artifacts', taskId +
-                    'artifacts.public.build.target.tar.bz2')
+name = os.path.join('ccov-artifacts',
+                    'latest.artifacts.public.build.target.tar.bz2')
+
 # Retrieving artifact
 urlretrieve('https://index.taskcluster.net/v1/task/gecko.v2.' +
             'mozilla-central.latest.firefox.linux64-ccov-opt/' +
             'artifacts/public/build/target.tar.bz2', name)
+
 # Extracting artifact
 with tarfile.open(name, 'r:bz2') as tar:
     tar.extractall()

--- a/latest_cov_build.py
+++ b/latest_cov_build.py
@@ -1,26 +1,21 @@
 import tarfile
-import sys
 import os
 import taskcluster
 try:
-    from urllib.parse import urlencode
-    from urllib.request import urlopen, urlretrieve
+    from urllib.request import urlretrieve
 except ImportError:
-    from urllib import urlencode, urlretrieve
-    from urllib2 import urlopen
+    from urllib import urlretrieve
 
 
 index = taskcluster.Index()
+taskId = index.findTask('gecko.v2.mozilla-central.' +
+                        'latest.firefox.linux64-ccov-opt')['taskId']
 queue = taskcluster.Queue()
-route = "gecko.v2.mozilla-central.latest.firefox.linux64-ccov-opt"
-taskId = index.findTask(route)['taskId']
-artifactName = 'public/build/target.tar.bz2'
+url = queue.buildUrl('getLatestArtifact', taskId,
+                     'public/build/target.tar.bz2')
 name = os.path.join('ccov-artifacts', taskId +
                     'artifacts.public.build.target.tar.bz2')
-url = queue.buildUrl('getLatestArtifact', taskId, artifactName)
-print(url)
 urlretrieve(url, name)
-tar = tarfile.open(name, 'r:bz2')
-tar.extractall()
-tar.close()
+with tarfile.open(name, 'r:bz2') as tar:
+    tar.extractall()
 os.remove(name)

--- a/latest_cov_build.py
+++ b/latest_cov_build.py
@@ -1,6 +1,8 @@
-import tarfile
 import os
+import tarfile
+
 import taskcluster
+
 try:
     from urllib.request import urlretrieve
 except ImportError:

--- a/latest_cov_build.py
+++ b/latest_cov_build.py
@@ -1,25 +1,26 @@
 import tarfile
 import sys
-import json
 import os
-from urllib import urlretrieve, urlencode
-from urllib2 import urlopen
+import taskcluster
+try:
+    from urllib.parse import urlencode
+    from urllib.request import urlopen, urlretrieve
+except ImportError:
+    from urllib import urlencode, urlretrieve
+    from urllib2 import urlopen
 
 
-def get_json(url, params=None):
-    if params is not None:
-        url += '?' + urlencode(params)
-
-    r = urlopen(url).read().decode('utf-8')
-
-    return json.loads(r)
-
-last_task = get_json('https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.firefox.linux64-ccov-opt')
-taskId = last_task['taskId']
-name = os.path.join('ccov-artifacts', taskId + 'artifacts.public.build.target.tar.bz2')
-urlretrieve('https://queue.taskcluster.net/v1/task/' + taskId + '/artifacts/public/build/target.tar.bz2', name)
+index = taskcluster.Index()
+queue = taskcluster.Queue()
+route = "gecko.v2.mozilla-central.latest.firefox.linux64-ccov-opt"
+taskId = index.findTask(route)['taskId']
+artifactName = 'public/build/target.tar.bz2'
+name = os.path.join('ccov-artifacts', taskId +
+                    'artifacts.public.build.target.tar.bz2')
+url = queue.buildUrl('getLatestArtifact', taskId, artifactName)
+print(url)
+urlretrieve(url, name)
 tar = tarfile.open(name, 'r:bz2')
 tar.extractall()
 tar.close()
-# target.tar.bz2 deleted
 os.remove(name)

--- a/latest_cov_build.py
+++ b/latest_cov_build.py
@@ -8,17 +8,18 @@ try:
 except ImportError:
     from urllib import urlretrieve
 
+
 # Retrieving task from index
 index = taskcluster.Index()
 taskId = index.findTask('gecko.v2.mozilla-central.' +
                         'latest.firefox.linux64-ccov-opt')['taskId']
-# Retrieving artifact from Queue
-queue = taskcluster.Queue()
-url = queue.buildUrl('getLatestArtifact', taskId,
-                     'public/build/target.tar.bz2')
+# taskId uniquelly identifies artifact
 name = os.path.join('ccov-artifacts', taskId +
                     'artifacts.public.build.target.tar.bz2')
-urlretrieve(url, name)
+# Retrieving artifact
+urlretrieve('https://index.taskcluster.net/v1/task/gecko.v2.' +
+            'mozilla-central.latest.firefox.linux64-ccov-opt/' +
+            'artifacts/public/build/target.tar.bz2', name)
 # Extracting artifact
 with tarfile.open(name, 'r:bz2') as tar:
     tar.extractall()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 selenium==3.4.3
+taskcluster==2.1.3 


### PR DESCRIPTION
Fixes #5.
 
The latest coverage build is downloaded by taskId retrieved from Index API of Taskcluster; extracted to the directory script was run, and the downloaded file is deleted after that. 

I have used ideas from your `firefox-code-coverage` repository from this file: https://github.com/marco-c/firefox-code-coverage/blob/5c8bc65ab17aa101183fdae5ed56fddf210a3620/codecoverage.py


