### PR TITLE
Added Travis Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # coverage-crawler
+[![Build Status](https://travis-ci.org/marco-c/coverage-crawler.svg?branch=master)](https://travis-ci.org/marco-c/coverage-crawler)
+
 A crawler to find websites that exercise code in Firefox that is not covered by unit tests


### PR DESCRIPTION
In reference to issue #10. Added travis badge to README.
![travis_badge](https://user-images.githubusercontent.com/37044655/37410412-96fb223c-27c6-11e8-9d8d-4d9e5b464142.png)