### PR TITLE
Download geckodriver automatically

### DIFF
--- a/latest_cov_build.py
+++ b/latest_cov_build.py
@@ -1,5 +1,10 @@
 import os
+import platform
+import sys
 import tarfile
+import zipfile
+
+import requests
 
 try:
     from urllib.request import urlretrieve
@@ -17,4 +22,51 @@ urlretrieve('https://index.taskcluster.net/v1/task/gecko.v2.' +
 # Extracting artifact
 with tarfile.open(name, 'r:bz2') as tar:
     tar.extractall()
+os.remove(name)
+
+# Geckodriver download
+# OS information for correct geckodriver version
+bitness = platform.architecture()[0]
+latest_version = requests.get('https://api.github.com/repos/mozilla/geckodriver/releases/latest')
+data = latest_version.json()
+tag_name = data['tag_name']
+base_url = 'https://github.com/mozilla/geckodriver/releases/download/' + tag_name + '/geckodriver-' + tag_name + '-'
+
+# Linux OS
+if sys.platform.startswith('linux'):
+    if bitness == '64bit':
+        version = 'linux64.tar.gz'
+    else:
+        version = 'linux32.tar.gz'
+
+# MacOS
+elif sys.platform.startswith('darwin'):
+    version = 'macos.tar.gz'
+
+# Windows or Cygwin
+elif sys.platform.startswith('cygwin') or sys.platform.startswith('win32'):
+    if bitness == '64bit':
+        version = 'win64.zip'
+    else:
+        version = 'win32.zip'
+
+# Create 'tools/' directory if doesn't exist
+if not os.path.exists('tools'):
+    os.makedirs('tools')
+
+# Download
+name = os.path.join('tools', version)
+base_url += version
+urlretrieve(base_url, name)
+
+# Extract
+if version.endswith('zip'):
+    with zipfile.ZipFile(name, 'r') as zip_ref:
+        zip_ref.extractall('tools')
+
+# MacOS and Linux OS have 'tar.gz' extensions
+elif base_url.endswith('tar.gz'):
+    with tarfile.open(name, 'r:gz') as tar:
+        tar.extractall(path='tools')
+
 os.remove(name)


### PR DESCRIPTION
Fixes #14.

Added functionality to `latest_cov_build.py` to download the latest version of Geckodriver to `tools/` folder, which should be created if doesn't exist. 
Differentiated between `.zip` Windows archives and `tar.gz` Unix archives. 

Tested on Linux Ubuntu 16.04.
