### PR TITLE
fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A crawler to find websites that exercise code in Firefox that is not covered by 
 
 ## Usage
 
-- Install requirements with `pip install -r requirements`;
+- Install requirements with `pip install -r requirements.txt`;
 - Install development requirements with `pip install -r test-requirements.txt`;
 - Run the `latest_cov_build.py` script to download the latest Firefox coverage build;
 - Run the `crawler.py` script.


### PR DESCRIPTION
I've occasionally missed `.txt` in `pip install -r requirements.txt`. 