### PR TITLE
GCOV env vars

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -1,6 +1,8 @@
 import json
 import os
 import random
+import sys
+import tempfile
 import time
 import traceback
 
@@ -177,6 +179,20 @@ def run_all(driver):
     driver.quit()
 
 
+# Environmental vars set to overwrite default location of .gcda files
+if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
+    prefix = '/builds/worker/workspace/build/src/'
+    strip_count = prefix.count('/')
+elif sys.platform.startswith('cygwin') or sys.platform.startswith('win32'):
+    prefix = 'z:/build/build/src/'
+    strip_count = prefix.count('/') + 1
+
+# Remove a prefix from the path where .gcda files are stored
+os.environ['GCOV_PREFIX_STRIP'] = str(strip_count)
+
+# Returns absolute path for created temp file
+gcov_dir = tempfile.mkdtemp()
+os.environ['GCOV_PREFIX'] = gcov_dir
 os.environ['PATH'] += os.pathsep + os.path.abspath('tools')
 os.environ['MOZ_HEADLESS'] = '1'
 


### PR DESCRIPTION
Hi!
I've relied on [your script](https://dxr.mozilla.org/mozilla-central/source/testing/mozharness/mozharness/mozilla/testing/codecoverage.py#90) to set `GCOV_PREFIX` and `GCOV_PREFIX_STRIPE` environmental variables to change the location for `.gcda` files (which is by default is the directory where the script was run). 
However, I have used `sys` library instead of `mozinfo`.

I've tried on Ubuntu and the script created me a temporary directory where `.gcda` files were stored.

P.S. I could not find information about these environmental variables on MacOS, so I have decided to add it to the same conditional branch as Linux as they are both Unix based.

Fixes #19. 

