### PR TITLE
Updated directory for files download

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -197,6 +197,6 @@ os.environ['PATH'] += os.pathsep + os.path.abspath('tools')
 os.environ['MOZ_HEADLESS'] = '1'
 
 # Webdriver uses Firefox Binaries from downloaded cov build
-driver = webdriver.Firefox(firefox_binary='firefox/firefox-bin')
+driver = webdriver.Firefox(firefox_binary='tools/firefox/firefox-bin')
 
 run_all(driver)

--- a/latest_cov_build.py
+++ b/latest_cov_build.py
@@ -22,12 +22,12 @@ taskId = index.findTask('gecko.v2.mozilla-central.' +
 # Download artifacts
 for name in ['target.tar.bz2', 'target.code-coverage-gcno.zip', 'chrome-map.json']:
     url = queue.buildUrl('getLatestArtifact', taskId, 'public/build/{}'.format(name))
-    urlretrieve(url, name)
+    urlretrieve(url, os.path.join('tools', name))
 
 # Extracting coverage build artifact
-with tarfile.open('target.tar.bz2', 'r:bz2') as tar:
-    tar.extractall()
-os.remove('target.tar.bz2')
+with tarfile.open('tools/target.tar.bz2', 'r:bz2') as tar:
+    tar.extractall(path='tools')
+os.remove('tools/target.tar.bz2')
 
 # Geckodriver download
 # OS information for correct geckodriver version


### PR DESCRIPTION
All files are now downloaded to `tools/` directory. Changed location of Firefox binaries in `crawler.py`.

Fixes #28. 