### PR TITLE
Retrieve coverage report from mozilla-central tests

### DIFF
--- a/latest_cov_build.py
+++ b/latest_cov_build.py
@@ -93,6 +93,4 @@ for filename in ['tools/target.code-coverage-gcno.zip', 'tools/target.tar.bz2', 
 
 # Download Firefox coverage report
 codecoverage.download_coverage_artifacts(taskId, None)
-codecoverage.generate_info('tools/grcov')
-codecoverage.download_genhtml()
-codecoverage.generate_report('tools/firefox')
+codecoverage.generate_report('tools/grcov', 'coveralls+', 'firefox_report.json')

--- a/latest_cov_build.py
+++ b/latest_cov_build.py
@@ -93,4 +93,4 @@ for filename in ['tools/target.code-coverage-gcno.zip', 'tools/target.tar.bz2', 
 
 # Download Firefox coverage report
 codecoverage.download_coverage_artifacts(taskId, None)
-codecoverage.generate_report('tools/grcov', 'coveralls+', 'firefox_report.json')
+codecoverage.generate_report('tools/grcov', 'coveralls+', 'tests_report.json')

--- a/latest_cov_build.py
+++ b/latest_cov_build.py
@@ -6,6 +6,7 @@ import sys
 import tarfile
 import zipfile
 
+import codecoverage
 import requests
 import taskcluster
 
@@ -89,3 +90,9 @@ for filename in ['tools/target.code-coverage-gcno.zip', 'tools/target.tar.bz2', 
         with tarfile.open(filename, mode) as tar:
             tar.extractall(path='tools')
     os.remove(filename)
+
+# Download Firefox coverage report
+codecoverage.download_coverage_artifacts(taskId, None)
+codecoverage.generate_info('tools/grcov')
+codecoverage.download_genhtml()
+codecoverage.generate_report('tools/firefox')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 selenium==3.4.3
-taskcluster==2.1.3 
+taskcluster==2.1.3
+-e git+https://github.com/marco-c/firefox-code-coverage#egg=firefox_code_coverage


### PR DESCRIPTION
Fixes #42 
I haven't used revision value through GECKO_HEAD_REV because as I understood it was required to find the taskId but I already have this functionality implemented with Taskcluster function. 

P.S. I've added lines after decompression of archives and not in Download section because I need decompressed grcov and Firefox build to download archive. 