### PR TITLE
Clean coverage if has no problems

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -32,7 +32,7 @@ def compare_source_files_objects(obj1, obj2, ignore_hits):
                         if func1['exec'] is False and func2['exec'] is True:
                             diff_funcs.append(func2)
 
-    if len(diff_funcs) == 0 and len(diff_cov) == 0:
+    if len(diff_funcs) == 0 and len(diff_cov) == 0 or all(cov == 0 or cov is None for cov in diff_cov) and len(diff_funcs) == 0:
         return None
     else:
         obj1['coverage'] = diff_cov
@@ -49,8 +49,7 @@ def compare_reports(baseline_report, report, ignore_hits):
         for j in coverage:
             comp_result = compare_source_files_objects(i, j, ignore_hits)
             if comp_result is not None:
-                if len(comp_result['functions']) != 0 or not all(cov == 0 or cov is None for cov in comp_result['coverage']):
-                    source_files.append(comp_result)
+                source_files.append(comp_result)
     diff_report['source_files'] = source_files
     for name in ['git', 'repo_token', 'service_job_number', 'service_name', 'service_number']:
         diff_report[name] = baseline_report[name]

--- a/diff.py
+++ b/diff.py
@@ -32,7 +32,7 @@ def compare_source_files_objects(obj1, obj2, ignore_hits):
                         if func1['exec'] is False and func2['exec'] is True:
                             diff_funcs.append(func2)
 
-    if len(diff_funcs) == 0 and len(diff_cov) == 0 or all(cov == 0 or cov is None for cov in diff_cov) and len(diff_funcs) == 0:
+    if len(diff_funcs) == 0 and all(cov == 0 or cov is None for cov in diff_cov):
         return None
     else:
         obj1['coverage'] = diff_cov

--- a/diff.py
+++ b/diff.py
@@ -49,7 +49,8 @@ def compare_reports(baseline_report, report, ignore_hits):
         for j in coverage:
             comp_result = compare_source_files_objects(i, j, ignore_hits)
             if comp_result is not None:
-                source_files.append(comp_result)
+                if len(comp_result['functions']) != 0 or not all(cov == 0 or cov is None for cov in comp_result['coverage']):
+                    source_files.append(comp_result)
     diff_report['source_files'] = source_files
     for name in ['git', 'repo_token', 'service_job_number', 'service_name', 'service_number']:
         diff_report[name] = baseline_report[name]

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -424,6 +424,88 @@ def test_compare_reports():
     }
 
 
+def test_compare_reports_coverage_no_problems():
+    baseline_report = {
+        'git': {
+            'branch': 'master',
+            'head': {
+                'id': 'UNUSED'
+            }
+        },
+        'repo_token': 'UNUSED',
+        'service_job_number': '',
+        'service_name': '',
+        'service_number': '',
+        'source_files': [
+            {
+                'functions': [
+                    {
+                        'name': 'func1',
+                        'start': 36,
+                        'exec': True
+                    }
+                ],
+                'branches': [],
+                'name': 'obj-firefox/dist/include/mozilla/dom/DOMRectListBinding.h',
+                'coverage': [
+                    None,
+                    2,
+                    None,
+                    1,
+                    5
+                ],
+                'source_digest': 'another_generated_number_with_literals'
+            }
+        ]
+    }
+    report = {
+        'git': {
+            'branch': 'master',
+            'head': {
+                'id': 'UNUSED'
+            }
+        },
+        'repo_token': 'UNUSED',
+        'service_job_number': '',
+        'service_name': '',
+        'service_number': '',
+        'source_files': [
+            {
+                'functions': [
+                    {
+                        'name': 'func1',
+                        'start': 36,
+                        'exec': True
+                    }
+                ],
+                'branches': [],
+                'name': 'obj-firefox/dist/include/mozilla/dom/DOMRectListBinding.h',
+                'coverage': [
+                    None,
+                    0,
+                    None,
+                    0,
+                    5
+                ],
+                'source_digest': 'another_generated_number_with_literals2'
+            }
+        ]
+    }
+    assert diff.compare_reports(baseline_report, report, False) == {
+        'git': {
+            'branch': 'master',
+            'head': {
+                'id': 'UNUSED'
+            }
+        },
+        'repo_token': 'UNUSED',
+        'service_job_number': '',
+        'service_name': '',
+        'service_number': '',
+        'source_files': []
+    }
+
+
 def test_compare_reports_2_files():
     baseline_report = {
         'git': {


### PR DESCRIPTION
Fixes #69 
We discussed this before: to remove source files that have no problems in them from diff report.  This decreased the size of diff report in ~10 times. All the problematic parts are now seen in JSON diff file. 