### PR TITLE
Ignore third party files

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -265,7 +265,6 @@ with tempfile.TemporaryDirectory() as gcov_dir, tempfile.TemporaryDirectory() as
     with open('output.json', 'w+') as outfile:
         subprocess.check_call(grcov_command, stdout=outfile)
 
-    data_folder = '1a347af9-8cac-4dbc-a349-66e982c53956'
     with open('tests_report.json') as baseline_rep, open('output.json') as rep:
         baseline_report = json.load(baseline_rep)
         report = json.load(rep)

--- a/crawler.py
+++ b/crawler.py
@@ -206,15 +206,6 @@ def run_all(driver, data_folder):
     driver.quit()
 
 
-def create_diff_report(baseline_report, report, ignore_hits, ignore_third_party=True):
-    if ignore_third_party:
-        report = filterpaths.ignore_third_party_filter(report)
-
-    diff_report = diff.compare_reports(baseline_report, report, ignore_hits)
-
-    return diff_report
-
-
 # Environmental vars set to overwrite default location of .gcda files
 if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
     prefix = '/builds/worker/workspace/build/src/'
@@ -269,8 +260,10 @@ with tempfile.TemporaryDirectory() as gcov_dir, tempfile.TemporaryDirectory() as
         baseline_report = json.load(baseline_rep)
         report = json.load(rep)
 
+    filterpaths.ignore_third_party_filter(report)
+
     # Create diff report
-    diff_report = create_diff_report(baseline_report, report, True)
+    diff_report = diff.compare_reports(baseline_report, report, True)
     with open('{}/diff.json'.format(data_folder), 'w') as outfile:
         json.dump(diff_report, outfile)
 

--- a/filterpaths.py
+++ b/filterpaths.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+
+def ignore_third_party_filter(report):
+
+    with open('mozilla-central/tools/rewriting/ThirdPartyPaths.txt') as f:
+        third_party_paths = [path.strip('\n') for path in f]
+
+    files = report['source_files']
+
+    filtered_report = {}
+    filtered_files = []
+    for i in files:
+        if any(i['name'].startswith(path) for path in third_party_paths):
+                continue
+        filtered_files.append(i)
+    filtered_report['source_files'] = filtered_files
+    for name in ['git', 'repo_token', 'service_job_number', 'service_name', 'service_number']:
+        filtered_report[name] = report[name]
+
+    return filtered_report

--- a/filterpaths.py
+++ b/filterpaths.py
@@ -2,20 +2,6 @@
 
 
 def ignore_third_party_filter(report):
-
     with open('mozilla-central/tools/rewriting/ThirdPartyPaths.txt') as f:
         third_party_paths = [path.strip('\n') for path in f]
-
-    files = report['source_files']
-
-    filtered_report = {}
-    filtered_files = []
-    for i in files:
-        if any(i['name'].startswith(path) for path in third_party_paths):
-                continue
-        filtered_files.append(i)
-    filtered_report['source_files'] = filtered_files
-    for name in ['git', 'repo_token', 'service_job_number', 'service_name', 'service_number']:
-        filtered_report[name] = report[name]
-
-    return filtered_report
+    report['source_files'] = [sf for sf in report['source_files'] if not any(sf['name'].startswith(path) for path in third_party_paths)]

--- a/generatehtml.py
+++ b/generatehtml.py
@@ -6,7 +6,7 @@ import os
 import codecoverage
 
 
-def generate_html(data_folder):
+def generate_html(data_folder, ignore_third_party=False):
     with open('{}/diff.json'.format(data_folder), 'r') as report:
         parsed_json = json.load(report)
 
@@ -15,6 +15,18 @@ def generate_html(data_folder):
     source_files = parsed_json['source_files']
     file_obj.write('TN\n')
     for source_file in source_files:
+        if ignore_third_party is True:
+            ignore = False
+            with open('mozilla-central/tools/rewriting/ThirdPartyPaths.txt') as f:
+                for path in list(f):
+                    if source_file['name'].startswith(path.strip('\n')):
+                        ignore = True
+                        break
+
+            # If source file is third party, skip it
+            if ignore is True:
+                continue
+
         file_obj.write('SF:{}\n'.format(source_file['name']))
         executed = 0
 

--- a/generatehtml.py
+++ b/generatehtml.py
@@ -14,7 +14,6 @@ def generate_html(data_folder):
 
     source_files = parsed_json['source_files']
     file_obj.write('TN\n')
-
     for source_file in source_files:
         file_obj.write('SF:{}\n'.format(source_file['name']))
         executed = 0

--- a/generatehtml.py
+++ b/generatehtml.py
@@ -6,7 +6,7 @@ import os
 import codecoverage
 
 
-def generate_html(data_folder, ignore_third_party=False):
+def generate_html(data_folder):
     with open('{}/diff.json'.format(data_folder), 'r') as report:
         parsed_json = json.load(report)
 
@@ -14,19 +14,8 @@ def generate_html(data_folder, ignore_third_party=False):
 
     source_files = parsed_json['source_files']
     file_obj.write('TN\n')
+
     for source_file in source_files:
-        if ignore_third_party is True:
-            ignore = False
-            with open('mozilla-central/tools/rewriting/ThirdPartyPaths.txt') as f:
-                for path in list(f):
-                    if source_file['name'].startswith(path.strip('\n')):
-                        ignore = True
-                        break
-
-            # If source file is third party, skip it
-            if ignore is True:
-                continue
-
         file_obj.write('SF:{}\n'.format(source_file['name']))
         executed = 0
 


### PR DESCRIPTION
Fixes #76 
I've also added small bug fix: previously lines were starting from 0 instead of 1. Added to this PR since it is very small. 
Now, 1.4% is uncovered for the same diff.json that was yesterday compared to 1.3% with third-party files. The report is quite small and I added it to the PR. 
[report.zip](https://github.com/marco-c/coverage-crawler/files/2122949/report.zip)
