### PR TITLE
Modify PYTHONPATH in the script

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -233,7 +233,7 @@ def run_all():
 
                 # Add paths to Mozilla-central modules
                 sys.path.insert(0, 'tools/mozbuild/codecoverage')
-                sys.path.insert(0,'tools')
+                sys.path.insert(0, 'tools')
 
                 from lcov_rewriter import LcovFileRewriter
 

--- a/crawler.py
+++ b/crawler.py
@@ -231,8 +231,9 @@ def run_all():
                     traceback.print_exc()
                     close_all_windows_except_first(driver)
 
-                # Add paths to Mozilla-central lcov_rewriter module
+                # Add paths to Mozilla-central modules
                 sys.path.insert(0, 'tools/mozbuild/codecoverage')
+                sys.path.insert(0,'tools')
 
                 from lcov_rewriter import LcovFileRewriter
 


### PR DESCRIPTION
To add the path to `mozpack` module in Mozilla-central folder. Currently, I am manually adding it with `export PYTHONPATH='path_to_module`. Probably, it will be better to add it in the script. 